### PR TITLE
Add vars

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,21 +119,18 @@ func (sc *SailThruClient) getPostForm(items map[string]interface{}) url.Values {
 
 //CreateJob Func that creates a sailthru job.  Call must specify the type of job, the name of the list and the format of the returned data (json|xml)
 //Keep in mind that CreateJob does not immediately return the contents of the job, it starts the job and returns a jobID.  The status of the job is checked via the GetJob func
-func (sc *SailThruClient) CreateJob(jobType string, listName string, format string) (*CreateJobResponse, error) {
+func (sc *SailThruClient) CreateJob(jobType string, listName string, fields map[string]map[string]interface{}, format string) (*CreateJobResponse, error) {
+
+	// vars := map[string]int{"user_id": 1}
+	// fieldValues := map[string]map[string]int{"vars": vars}
+	//
 	r := CreateJobResponse{}
 	if _, ok := allowedJobTypes[jobType]; !ok {
 		return nil, fmt.Errorf("Invalid jobType: %v", jobType)
 	}
 	posturl := fmt.Sprintf(apiURLPost, sc.baseURL, "job", format)
-	/*
-		  TODO:
-			vars needs a different name
-			fieldValues needs to be injected form the CreateJob, not hard coded here.
-	*/
-	vars := map[string]int{"user_id": 1}
-	fieldValues := map[string]map[string]int{"vars": vars}
 
-	items := map[string]interface{}{"job": jobType, "list": listName, "fields": fieldValues}
+	items := map[string]interface{}{"job": jobType, "list": listName, "fields": fields}
 	form := sc.getPostForm(items)
 	req, reqErr := http.NewRequest("POST", posturl, bytes.NewBufferString(form.Encode()))
 	if reqErr != nil {
@@ -188,8 +185,8 @@ func (sc *SailThruClient) GetCSVData(path string) (io.ReadCloser, error) {
 }
 
 //CreateJobAndReturnJob This will create the job, and then return the contents of the job, providing it does not timeout(value is seconds)
-func (sc *SailThruClient) CreateJobAndReturnJob(jobType string, listName string, format string, timeout int) (io.ReadCloser, error) {
-	cjresp, err := sc.CreateJob(jobType, listName, format)
+func (sc *SailThruClient) CreateJobAndReturnJob(jobType string, listName string, fields map[string]map[string]interface{}, format string, timeout int) (io.ReadCloser, error) {
+	cjresp, err := sc.CreateJob(jobType, listName, fields, format)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -121,9 +121,6 @@ func (sc *SailThruClient) getPostForm(items map[string]interface{}) url.Values {
 //Keep in mind that CreateJob does not immediately return the contents of the job, it starts the job and returns a jobID.  The status of the job is checked via the GetJob func
 func (sc *SailThruClient) CreateJob(jobType string, listName string, fields map[string]map[string]interface{}, format string) (*CreateJobResponse, error) {
 
-	// vars := map[string]int{"user_id": 1}
-	// fieldValues := map[string]map[string]int{"vars": vars}
-	//
 	r := CreateJobResponse{}
 	if _, ok := allowedJobTypes[jobType]; !ok {
 		return nil, fmt.Errorf("Invalid jobType: %v", jobType)

--- a/client.go
+++ b/client.go
@@ -126,18 +126,13 @@ func (sc *SailThruClient) CreateJob(jobType string, listName string, format stri
 	}
 	posturl := fmt.Sprintf(apiURLPost, sc.baseURL, "job", format)
 	/*
-			{
-		   "job":"export_list_data",
-		   "list":"adhoc_3",
-		   "fields":{
-		      "vars":{
-		         "user_id":1
-		      }
-		   }
-		}
+		  TODO:
+			vars needs a different name
+			fieldValues needs to be injected form the CreateJob, not hard coded here.
 	*/
 	vars := map[string]int{"user_id": 1}
 	fieldValues := map[string]map[string]int{"vars": vars}
+
 	items := map[string]interface{}{"job": jobType, "list": listName, "fields": fieldValues}
 	form := sc.getPostForm(items)
 	req, reqErr := http.NewRequest("POST", posturl, bytes.NewBufferString(form.Encode()))

--- a/client.go
+++ b/client.go
@@ -125,9 +125,21 @@ func (sc *SailThruClient) CreateJob(jobType string, listName string, format stri
 		return nil, fmt.Errorf("Invalid jobType: %v", jobType)
 	}
 	posturl := fmt.Sprintf(apiURLPost, sc.baseURL, "job", format)
-	items := map[string]interface{}{"job": jobType, "list": listName, "fields": "vars"}
+	/*
+			{
+		   "job":"export_list_data",
+		   "list":"adhoc_3",
+		   "fields":{
+		      "vars":{
+		         "user_id":1
+		      }
+		   }
+		}
+	*/
+	vars := map[string]int{"user_id": 1}
+	fieldValues := map[string]map[string]int{"vars": vars}
+	items := map[string]interface{}{"job": jobType, "list": listName, "fields": fieldValues}
 	form := sc.getPostForm(items)
-
 	req, reqErr := http.NewRequest("POST", posturl, bytes.NewBufferString(form.Encode()))
 	if reqErr != nil {
 		return nil, reqErr

--- a/client_test.go
+++ b/client_test.go
@@ -43,6 +43,7 @@ func TestCreateJob(t *testing.T) {
 	resp, err := sc.CreateJob("export_list_data", "ad_hoc_test_list_1", "json")
 	if err != nil {
 		t.Error(err)
+		t.FailNow()
 	}
 	if resp.JobID != expectedJobID {
 		t.Errorf("Expected %v, got %v\n", expectedJobID, resp.JobID)

--- a/client_test.go
+++ b/client_test.go
@@ -40,7 +40,10 @@ func TestCreateJob(t *testing.T) {
 	mc := NewMockClient(normalJob)
 	c := getTestConfig()
 	sc := NewSailThruClient(&mc, c)
-	resp, err := sc.CreateJob("export_list_data", "ad_hoc_test_list_1", "json")
+
+	fields := map[string]map[string]interface{}{"vars": {"user_id": 1}}
+
+	resp, err := sc.CreateJob("export_list_data", "ad_hoc_test_list_1", fields, "json")
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -55,8 +58,8 @@ func TestCreateInvalidJobType(t *testing.T) {
 	mc := NewMockClient(normalJob)
 	c := getTestConfig()
 	sc := NewSailThruClient(&mc, c)
-
-	_, err := sc.CreateJob("invalid_job_type", "ad_hoc_test_list_1", "json")
+	fields := map[string]map[string]interface{}{"vars": {"user_id": 1}}
+	_, err := sc.CreateJob("invalid_job_type", "ad_hoc_test_list_1", fields, "json")
 	if err == nil {
 		t.Errorf("Expected %v, got %v\n", expectedErrorStr, nil)
 	} else {

--- a/httpmockclient.go
+++ b/httpmockclient.go
@@ -84,8 +84,8 @@ func NewMockClient(mt mockType) MockClient {
 	return mc
 }
 
-func getMapFromJSONForm(req *http.Request) (map[string]string, error) {
-	jsonMap := make(map[string]string)
+func getMapFromJSONForm(req *http.Request) (map[string]interface{}, error) {
+	jsonMap := make(map[string]interface{})
 	errJSON := json.Unmarshal([]byte(req.FormValue("json")), &jsonMap)
 	if errJSON != nil {
 		return nil, errJSON


### PR DESCRIPTION
SailThru changed their API.  Previously, all of the vars would come down in the Job request for `export_list_data`, now each field has to be explicitly called.  

This PR adds the ability to add `fields` and `vars` so that the request json looks like this:

```json
{
   "fields":{
      "vars":{
         "user_id":1
      }
   },
   "job":"export_list_data",
   "list":"adhoc_3"
}
```